### PR TITLE
[deep-relation] add a model using relation as label

### DIFF
--- a/deeprelation/model/hfmodel/relation_model.py
+++ b/deeprelation/model/hfmodel/relation_model.py
@@ -1,4 +1,4 @@
-from deeprelation.model.hfmodel.base_tokenizer_model import BaseTokenzierModel
+from deeprelation.model.hfmodel.relation_type_model import RelationTypeModel
 from deeprelation.model.dataset import SemiEvalDataset
 from deeprelation.data.semieval.semieval_data import SemiEvalData
 from typing import List
@@ -9,25 +9,17 @@ from transformers import (
 )
 
 
-class RelationTypeModel(BaseTokenzierModel):
+class RelationModel(RelationTypeModel):
 
     def _build_dataset(self, dataset: List[SemiEvalData]) -> SemiEvalDataset:
-        relation_types = [data.get_relation_type() for data in dataset]
+        relations = [data.get_relation() for data in dataset]
         sentences = [" ".join(data.get_bag_of_words()) for data in dataset]
-        labels = [self.relation_type_dict[t] for t in relation_types]
+        labels = [self.relation_dict[t] for t in relations]
         input_ids, attention_masks = self.tokenize(sentences)
         return SemiEvalDataset(input_ids, attention_masks, labels)
 
-    def build_dataset(self, dataset_name: str) -> SemiEvalDataset:
-        if dataset_name == "training":
-            return self._build_dataset(self.train_data)
-        elif dataset_name == "testing":
-            return self._build_dataset(self.test_data)
-        else:
-            raise RuntimeError("Dataset name invalid: " + dataset_name)
-
     def build_model(self) -> PreTrainedModel:
-        num_labels = len(self.relation_type_dict)
+        num_labels = len(self.relation_dict)
         model_config = AutoConfig.from_pretrained(self.hf_model_name,
                                                   num_labels=num_labels)
         model = AutoModelForSequenceClassification.from_pretrained(


### PR DESCRIPTION
Instead of using relation type as label. Adding a new model using relation as label. Using relation as label will take entity order into considerations